### PR TITLE
Fix: Display blog posts on homepage using Jekyll templating

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,227 @@
+---
+layout: default
+---
+
+<article class="post">
+    <header class="post-header">
+        <h1 class="post-title">{{ page.title }}</h1>
+        <div class="post-meta">
+            <span class="post-date">{{ page.date | date: "%B %-d, %Y" }}</span>
+            {% if page.categories.size > 0 %}
+            <span class="post-categories">
+                {% for category in page.categories %}
+                <span class="category-badge">{{ category }}</span>
+                {% endfor %}
+            </span>
+            {% endif %}
+        </div>
+        {% if page.description %}
+        <p class="post-description">{{ page.description }}</p>
+        {% endif %}
+    </header>
+    
+    <div class="post-content">
+        {{ content }}
+    </div>
+    
+    {% if page.tags.size > 0 %}
+    <footer class="post-footer">
+        <div class="post-tags">
+            <span class="tags-label">Tags:</span>
+            {% for tag in page.tags %}
+            <span class="tag">{{ tag }}</span>
+            {% endfor %}
+        </div>
+    </footer>
+    {% endif %}
+</article>
+
+<nav class="post-navigation">
+    <div class="nav-links">
+        {% if page.previous.url %}
+        <a class="nav-previous" href="{{ page.previous.url }}" title="{{ page.previous.title }}">
+            <span class="nav-subtitle">Previous Post</span>
+            <span class="nav-title">{{ page.previous.title | truncate: 50 }}</span>
+        </a>
+        {% endif %}
+        
+        <a class="nav-home" href="/">
+            <span class="nav-subtitle">Back to</span>
+            <span class="nav-title">All Posts</span>
+        </a>
+        
+        {% if page.next.url %}
+        <a class="nav-next" href="{{ page.next.url }}" title="{{ page.next.title }}">
+            <span class="nav-subtitle">Next Post</span>
+            <span class="nav-title">{{ page.next.title | truncate: 50 }}</span>
+        </a>
+        {% endif %}
+    </div>
+</nav>
+
+<style>
+.post-header {
+    margin-bottom: 40px;
+    padding-bottom: 25px;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.post-title {
+    color: var(--primary-dark);
+    font-size: 2.5rem;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 20px;
+    border: none;
+    padding: 0;
+}
+
+.post-meta {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    margin-bottom: 15px;
+    font-size: 0.95rem;
+    color: var(--light-text);
+}
+
+.post-date {
+    font-weight: 500;
+}
+
+.post-categories {
+    display: flex;
+    gap: 8px;
+}
+
+.category-badge {
+    background: var(--primary-blue);
+    color: white;
+    padding: 4px 10px;
+    border-radius: 15px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    font-family: var(--font-family-mono);
+}
+
+.post-description {
+    font-size: 1.1rem;
+    color: var(--light-text);
+    font-style: italic;
+    margin: 0;
+    line-height: 1.6;
+}
+
+.post-content {
+    margin-bottom: 40px;
+}
+
+.post-footer {
+    margin-top: 40px;
+    padding-top: 25px;
+    border-top: 1px solid var(--border-color);
+}
+
+.post-tags {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.tags-label {
+    font-weight: 600;
+    color: var(--primary-dark);
+}
+
+.tag {
+    background: var(--background-alt);
+    color: var(--dark-text);
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 0.85rem;
+    font-family: var(--font-family-mono);
+    border: 1px solid var(--border-color);
+}
+
+.post-navigation {
+    margin-top: 50px;
+    padding-top: 30px;
+    border-top: 2px solid var(--border-color);
+}
+
+.nav-links {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 20px;
+    align-items: center;
+}
+
+.nav-links a {
+    display: flex;
+    flex-direction: column;
+    padding: 15px 20px;
+    background: var(--background-alt);
+    border-radius: var(--border-radius);
+    text-decoration: none;
+    transition: all 0.2s ease;
+    border: 1px solid var(--border-color);
+}
+
+.nav-links a:hover {
+    background: var(--primary-blue);
+    color: white;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(41, 128, 185, 0.2);
+}
+
+.nav-previous {
+    text-align: left;
+}
+
+.nav-next {
+    text-align: right;
+}
+
+.nav-home {
+    text-align: center;
+}
+
+.nav-subtitle {
+    font-size: 0.8rem;
+    color: var(--light-text);
+    font-weight: 500;
+    margin-bottom: 4px;
+}
+
+.nav-links a:hover .nav-subtitle {
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.nav-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--primary-dark);
+}
+
+.nav-links a:hover .nav-title {
+    color: white;
+}
+
+@media (max-width: 600px) {
+    .nav-links {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+    
+    .post-title {
+        font-size: 2rem;
+    }
+    
+    .post-meta {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+}
+</style>

--- a/index.html
+++ b/index.html
@@ -137,6 +137,56 @@
         .badge.embedded { background: var(--secondary-orange); }
         .badge.retro { background: var(--secondary-purple); }
         .badge.coding { background: var(--secondary-green); }
+        .post-preview {
+            background: var(--background);
+            border: 1px solid var(--border-color);
+            border-radius: var(--border-radius);
+            padding: 20px;
+            margin-bottom: 20px;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .post-preview:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .post-preview h3 {
+            margin: 0 0 10px 0;
+            font-size: 1.4rem;
+            font-weight: 600;
+        }
+        .post-preview h3 a {
+            color: var(--primary-dark);
+            text-decoration: none;
+        }
+        .post-preview h3 a:hover {
+            color: var(--primary-blue);
+        }
+        .post-meta {
+            margin-bottom: 15px;
+            font-size: 0.9rem;
+            color: var(--light-text);
+        }
+        .post-meta .date {
+            margin-right: 15px;
+        }
+        .post-meta .categories {
+            display: inline-flex;
+            gap: 5px;
+        }
+        .post-excerpt {
+            color: var(--dark-text);
+            line-height: 1.6;
+            margin-bottom: 15px;
+        }
+        .read-more {
+            color: var(--primary-blue);
+            text-decoration: none;
+            font-weight: 500;
+            font-size: 0.9rem;
+        }
+        .read-more:hover {
+            color: var(--primary-dark);
+        }
     </style>
 </head>
 <body>
@@ -157,17 +207,37 @@
         
         <div class="posts">
             <h2>Recent Posts</h2>
-            <div class="coming-soon">
-                <p>Blog posts coming soon...</p>
-                <p>Stay tuned for content about:</p>
-                <div class="tech-badges">
-                    <span class="badge ai">AI & LLMs</span>
-                    <span class="badge embedded">Embedded Systems</span>
-                    <span class="badge retro">Retro Computing</span>
-                    <span class="badge coding">Code Adventures</span>
-                    <span class="badge">Tech Tinkering</span>
+            {% if site.posts.size > 0 %}
+                {% for post in site.posts limit:5 %}
+                <article class="post-preview">
+                    <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+                    <div class="post-meta">
+                        <span class="date">{{ post.date | date: "%B %-d, %Y" }}</span>
+                        {% if post.categories.size > 0 %}
+                        <span class="categories">
+                            {% for category in post.categories %}
+                            <span class="badge">{{ category }}</span>
+                            {% endfor %}
+                        </span>
+                        {% endif %}
+                    </div>
+                    <p class="post-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 30 }}</p>
+                    <a href="{{ post.url }}" class="read-more">Read more →</a>
+                </article>
+                {% endfor %}
+            {% else %}
+                <div class="coming-soon">
+                    <p>Blog posts coming soon...</p>
+                    <p>Stay tuned for content about:</p>
+                    <div class="tech-badges">
+                        <span class="badge ai">AI & LLMs</span>
+                        <span class="badge embedded">Embedded Systems</span>
+                        <span class="badge retro">Retro Computing</span>
+                        <span class="badge coding">Code Adventures</span>
+                        <span class="badge">Tech Tinkering</span>
+                    </div>
                 </div>
-            </div>
+            {% endif %}
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Convert static homepage to use Jekyll Liquid templating to display actual blog posts
- Add post layout for individual blog post pages with navigation and metadata
- Homepage now shows blog posts when available, falls back to "coming soon" when empty

## Changes Made
- Updated index.html to use Jekyll loops to display posts dynamically
- Created _layouts/post.html with proper post styling and navigation
- Added responsive design for mobile devices
- Includes post metadata (date, categories, tags) and navigation between posts

## Test Plan
- [x] Homepage shows blog posts when they exist
- [x] Individual post pages render correctly with new layout
- [x] Navigation between posts works
- [x] Responsive design tested
- [x] Brand consistency maintained

This fixes the issue where blog posts weren't showing on qwertybits.io despite being merged to main.