### PR TITLE
Fix brand compliance CI to understand Jekyll layout inheritance

### DIFF
--- a/.github/workflows/brand-consistency.yml
+++ b/.github/workflows/brand-consistency.yml
@@ -130,10 +130,10 @@ jobs:
           fi
         done
         
-        # Check if layouts include brand.css
+        # Check if layouts include brand.css (or extend a layout that does)
         for file in $(find _layouts -name "*.html" 2>/dev/null || true); do
-          if ! grep -q "brand.css" "$file"; then
-            echo "❌ Layout $file does not include brand.css"
+          if ! grep -q "brand.css" "$file" && ! grep -q "layout: default" "$file"; then
+            echo "❌ Layout $file does not include brand.css or extend default layout"
             VIOLATIONS=$((VIOLATIONS + 1))
           fi
         done


### PR DESCRIPTION
## Summary
- Fixed brand compliance CI workflow to properly handle Jekyll layout inheritance
- The post.html layout extends default.html (which includes brand.css) but CI was checking for direct includes only
- Updated CI to accept layouts that either include brand.css directly OR extend the default layout

## Changes Made
- Modified brand-consistency.yml to check for `layout: default` in addition to direct brand.css includes
- This allows Jekyll layout inheritance to work properly while maintaining brand compliance

## Test Plan
- [x] Post layout extends default layout correctly
- [x] Default layout includes brand.css
- [x] CI now passes for inherited brand compliance
- [x] No actual brand violations exist

Fixes the failing brand-check that was blocking deployment.