### PR TITLE
Fix: Blog post timestamp was preventing publication

### DIFF
--- a/_posts/2025-08-31-claude-code-on-batocera-retro-gaming.md
+++ b/_posts/2025-08-31-claude-code-on-batocera-retro-gaming.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Hacking Batocera: Installing Claude Code on a Retro Gaming Console OS"
-date: 2025-08-31 15:30:00 -0000
+date: 2025-08-31 10:00:00 -0000
 categories: retro-computing gaming vintage
 tags: [retro, batocera, claude-code, gaming, linux, ai-tools, emulation, mini-pc]
 description: "How I got Anthropic's Claude Code CLI running on Batocera OS - from wrestling with pacman to portable Node.js solutions"


### PR DESCRIPTION
## Summary
The blog post was dated 15:30:00 (3:30 PM) but the current time is 12:15 PM. Jekyll doesn't publish posts with future timestamps by default.

## Fix
Changed the timestamp from 15:30:00 to 10:00:00 so the post is in the past and will be published immediately.

This should resolve why the blog post wasn't appearing on qwertybits.io despite being in the main branch.