### PR TITLE
Fix: Add Jekyll front matter to enable Liquid templating

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Problem
The index.html file contained Jekyll Liquid templating code (like {% raw %}{% if site.posts.size > 0 %}{% endraw %}) but it was being displayed as raw text on the website instead of being processed.

## Root Cause  
Jekyll only processes Liquid templating in files that have YAML front matter. Static .html files without front matter are served as-is.

## Solution
Added empty YAML front matter (--- ---) to the top of index.html so Jekyll will process the Liquid templating code.

## Result
- Blog posts will now display properly on the homepage
- Liquid templating code will be processed instead of shown as raw text
- Site.posts loop will work correctly to show actual blog posts

This should fix the homepage display issue where Jekyll templating code was visible as text.